### PR TITLE
package.json: make dev script an alias to start

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "gulp clean-build",
     "start": "npm run dev",
-    "serve": "sirv build --port 8080 --dev --no-clear",
+    "preview": "sirv build --port 8080 --dev --no-clear",
     "dev": "gulp dev",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:css": "stylelint src/css/ --rd --risd",


### PR DESCRIPTION
Same as jakearchibald/svgomg#410:

> Add a `serve` script to only serve the build folder

But I renamed the `serve` script to `preview`.