### PR TITLE
Add sub-toggle for `removeUnsafe` option of `removeDeprecatedAttrs` job

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -232,7 +232,7 @@ jobs:
     enabledByDefault: true
     options:
       - id: removeUnsafe
-        name: Including unsafe to remove
+        name: Include unsafe removals
 
   - id: applyTransforms
     name: Apply transforms

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -230,6 +230,9 @@ jobs:
   - id: removeDeprecatedAttrs
     name: Remove deprecated attributes
     enabledByDefault: true
+    options:
+      - id: removeUnsafe
+        name: Including unsafe to remove
 
   - id: applyTransforms
     name: Apply transforms

--- a/src/css/components/_settings.scss
+++ b/src/css/components/_settings.scss
@@ -17,12 +17,17 @@
 .setting-item-toggle {
   position: relative;
   cursor: pointer;
-  padding: 0 16px;
-  height: 51px;
+  padding: 4px 16px;
+  min-height: 43px;
   display: grid;
   grid-template-columns: max-content 1fr;
   align-items: center;
   gap: 19px;
+
+  &.nested {
+    padding-left: 72px; /* gap + x-padding + material-switch-width */
+    padding-top: 0;
+  }
 
   // stylelint-disable-next-line selector-no-qualifying-type
   input[type='checkbox'] {
@@ -35,11 +40,18 @@
 
   input:focus + .material-switch {
     .handle {
-      width: 25px;
-      height: 25px;
-      top: -5px;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5), inset 0 0 0 2px #ff5722;
+      outline: #ff5722 solid 2px;
     }
+  }
+  input:checked:focus + .material-switch {
+    .handle {
+      outline-color: #446117;
+    }
+  }
+
+  &:has(input:disabled) {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -177,7 +177,8 @@
                       <label class="setting-item-toggle nested">
                         <input type="checkbox"
                                name="{{ option.id }}"
-                               data-parent-job="{{ job.id }}">
+                               data-parent-job="{{ job.id }}"
+                               {% if not job.enabledByDefault %}disabled{% endif %}>
                         {% include "_partials/material-switch.html" %}
                         {{ option.name }}
                       </label>

--- a/src/index.html
+++ b/src/index.html
@@ -172,6 +172,17 @@
                     {% include "_partials/material-switch.html" %}
                     {{ job.name }}
                   </label>
+                  {% if job.options %}
+                    {% for option in job.options %}
+                      <label class="setting-item-toggle nested">
+                        <input type="checkbox"
+                               name="{{ option.id }}"
+                               data-parent-job="{{ job.id }}">
+                        {% include "_partials/material-switch.html" %}
+                        {{ option.name }}
+                      </label>
+                    {% endfor %}
+                  {% endif %}
                 {% endif %}
               {% endfor %}
             </section>

--- a/src/js/oxvg-worker/index.js
+++ b/src/js/oxvg-worker/index.js
@@ -57,9 +57,12 @@ function compress(svgInput, settings) {
   // Setup job list
   const floatPrecision = Number(settings.floatPrecision);
   const transformPrecision = Number(settings.transformPrecision);
+  const jobOptions = settings.jobOptions ?? {};
   const jobs = {};
   for (const [name, enabled] of Object.entries(settings.jobs)) {
     if (!enabled) continue;
+
+    const options = jobOptions[name] ?? {};
 
     jobs[name] = booleanJobs.includes(name)
       ? true
@@ -71,6 +74,7 @@ function compress(svgInput, settings) {
               ? 1
               : floatPrecision,
           transformPrecision,
+          ...options,
         };
 
     if (name === 'prefixIds') {

--- a/src/js/oxvg-worker/index.js
+++ b/src/js/oxvg-worker/index.js
@@ -57,16 +57,15 @@ function compress(svgInput, settings) {
   // Setup job list
   const floatPrecision = Number(settings.floatPrecision);
   const transformPrecision = Number(settings.transformPrecision);
-  const jobOptions = settings.jobOptions ?? {};
   const jobs = {};
-  for (const [name, enabled] of Object.entries(settings.jobs)) {
+  for (const [name, { enabled, options }] of Object.entries(settings.jobs)) {
     if (!enabled) continue;
-
-    const options = jobOptions[name] ?? {};
 
     jobs[name] = booleanJobs.includes(name)
       ? true
       : {
+          ...options,
+
           // 0 almost always breaks images when used on `cleanupNumericValues` and others.
           // Better to allow 0 for everything else, but switch to 1 for this job.
           floatPrecision:
@@ -74,7 +73,6 @@ function compress(svgInput, settings) {
               ? 1
               : floatPrecision,
           transformPrecision,
-          ...options,
         };
 
     if (name === 'prefixIds') {

--- a/src/js/page/ui/settings.js
+++ b/src/js/page/ui/settings.js
@@ -12,7 +12,7 @@ export default class Settings {
       this.container = document.querySelector('.settings');
       this._jobInputs = [
         ...this.container.querySelectorAll(
-          '.jobs .setting-item-toggle > input[type=checkbox]:not([data-parent-job])',
+          '.jobs input:not([data-parent-job])',
         ),
       ];
       this._jobOptionInputs = [
@@ -21,9 +21,6 @@ export default class Settings {
       this._globalInputs = [
         ...this.container.querySelectorAll('.global input'),
       ];
-      this._jobInputMap = new Map(
-        this._jobInputs.map((inputEl) => [inputEl.name, inputEl]),
-      );
 
       const scroller = this.container.querySelector('.settings-scroller');
       const resetBtn = this.container.querySelector('.setting-reset');
@@ -32,19 +29,29 @@ export default class Settings {
       this._resetRipple = new Ripple();
       resetBtn.append(this._resetRipple.container);
 
-      // map real range elements to Slider instances
+      // Map real range elements to Slider instances.
       this._sliderMap = new WeakMap();
-
-      // enhance ranges
       for (const range of ranges) {
         this._sliderMap.set(range, new MaterialSlider(range));
+      }
+
+      // Map parent jobs to job option input elements.
+      this._parentJobOptionInputsMap = new Map();
+      for (const jobOptionInput of this._jobOptionInputs) {
+        const parentJob = jobOptionInput.dataset.parentJob;
+        const existingOptionInputs =
+          this._parentJobOptionInputsMap.get(parentJob);
+        if (existingOptionInputs) {
+          existingOptionInputs.push(jobOptionInput);
+        } else {
+          this._parentJobOptionInputsMap.set(parentJob, [jobOptionInput]);
+        }
       }
 
       this.container.addEventListener('input', (event) =>
         this._onChange(event),
       );
       resetBtn.addEventListener('click', () => this._onReset());
-      this._syncDependentInputs();
 
       // TODO: revisit this
       // Stop double-tap text selection.
@@ -60,10 +67,6 @@ export default class Settings {
   _onChange(event) {
     clearTimeout(this._throttleTimeout);
 
-    if (event.target.type === 'checkbox') {
-      this._syncDependentInputs();
-    }
-
     // throttle range
     if (event.target.type === 'range') {
       this._throttleTimeout = setTimeout(
@@ -71,6 +74,15 @@ export default class Settings {
         150,
       );
     } else {
+      const optionInputs = this._parentJobOptionInputsMap.get(
+        event.target.name,
+      );
+      if (optionInputs) {
+        for (const optionInput of optionInputs) {
+          optionInput.disabled = !event.target.checked;
+        }
+      }
+
       this.emitter.emit('change');
     }
   }
@@ -90,17 +102,21 @@ export default class Settings {
 
     for (const inputEl of this._jobInputs) {
       inputEl.checked = inputEl.hasAttribute('checked');
-    }
 
-    this._syncDependentInputs();
+      const optionInputs = this._parentJobOptionInputsMap.get(inputEl.name);
+      if (optionInputs) {
+        for (const optionInput of optionInputs) {
+          optionInput.checked = optionInput.hasAttribute('checked');
+          optionInput.disabled = !inputEl.checked;
+        }
+      }
+    }
 
     this.emitter.emit('reset', oldSettings);
     this.emitter.emit('change');
   }
 
   setSettings(settings) {
-    const jobOptions = settings.jobOptions ?? {};
-
     for (const inputEl of this._globalInputs) {
       if (!(inputEl.name in settings)) continue;
 
@@ -113,23 +129,21 @@ export default class Settings {
 
     for (const inputEl of this._jobInputs) {
       if (!(inputEl.name in settings.jobs)) continue;
-      inputEl.checked = settings.jobs[inputEl.name];
-    }
+      inputEl.checked = settings.jobs[inputEl.name].enabled;
 
-    for (const inputEl of this._jobOptionInputs) {
-      const parentJob = inputEl.dataset.parentJob;
-      const parentOptions = jobOptions[parentJob] ?? settings.jobs[parentJob];
-
-      if (
-        parentOptions &&
-        typeof parentOptions === 'object' &&
-        inputEl.name in parentOptions
-      ) {
-        inputEl.checked = parentOptions[inputEl.name];
+      if (settings.jobs[inputEl.name].options) {
+        const optionInputs = this._parentJobOptionInputsMap.get(inputEl.name);
+        if (optionInputs) {
+          for (const optionInput of optionInputs) {
+            if (optionInput.name in settings.jobs[inputEl.name].options) {
+              optionInput.checked =
+                settings.jobs[inputEl.name].options[optionInput.name];
+            }
+            optionInput.disabled = !inputEl.checked;
+          }
+        }
       }
     }
-
-    this._syncDependentInputs();
   }
 
   getSettings() {
@@ -137,7 +151,6 @@ export default class Settings {
     const fingerprint = [];
     const output = {
       jobs: {},
-      jobOptions: {},
     };
 
     for (const inputEl of this._globalInputs) {
@@ -155,37 +168,21 @@ export default class Settings {
 
     for (const inputEl of this._jobInputs) {
       fingerprint.push(Number(inputEl.checked));
-      output.jobs[inputEl.name] = inputEl.checked;
-    }
+      output.jobs[inputEl.name] = { enabled: inputEl.checked };
 
-    for (const inputEl of this._jobOptionInputs) {
-      const parentJob = inputEl.dataset.parentJob;
-      const parentInput = this._jobInputMap.get(parentJob);
-
-      if (!output.jobOptions[parentJob]) {
-        output.jobOptions[parentJob] = {};
-      }
-
-      output.jobOptions[parentJob][inputEl.name] = inputEl.checked;
-
-      if (parentInput?.checked) {
-        fingerprint.push(
-          `${parentJob}:${inputEl.name}:${Number(inputEl.checked)}`,
-        );
+      const optionInputs = this._parentJobOptionInputsMap.get(inputEl.name);
+      if (optionInputs) {
+        output.jobs[inputEl.name].options = {};
+        for (const optionInput of optionInputs) {
+          fingerprint.push(`{${Number(optionInput.checked)}}`);
+          output.jobs[inputEl.name].options[optionInput.name] =
+            optionInput.checked;
+        }
       }
     }
 
     output.fingerprint = fingerprint.join(',');
 
     return output;
-  }
-
-  _syncDependentInputs() {
-    for (const inputEl of this._jobOptionInputs) {
-      const parentJob = inputEl.dataset.parentJob;
-      const parentInput = this._jobInputMap.get(parentJob);
-
-      inputEl.disabled = !parentInput?.checked;
-    }
   }
 }

--- a/src/js/page/ui/settings.js
+++ b/src/js/page/ui/settings.js
@@ -10,10 +10,20 @@ export default class Settings {
 
     domReady.then(() => {
       this.container = document.querySelector('.settings');
-      this._jobInputs = [...this.container.querySelectorAll('.jobs input')];
+      this._jobInputs = [
+        ...this.container.querySelectorAll(
+          '.jobs .setting-item-toggle > input[type=checkbox]:not([data-parent-job])',
+        ),
+      ];
+      this._jobOptionInputs = [
+        ...this.container.querySelectorAll('.jobs input[data-parent-job]'),
+      ];
       this._globalInputs = [
         ...this.container.querySelectorAll('.global input'),
       ];
+      this._jobInputMap = new Map(
+        this._jobInputs.map((inputEl) => [inputEl.name, inputEl]),
+      );
 
       const scroller = this.container.querySelector('.settings-scroller');
       const resetBtn = this.container.querySelector('.setting-reset');
@@ -34,6 +44,7 @@ export default class Settings {
         this._onChange(event),
       );
       resetBtn.addEventListener('click', () => this._onReset());
+      this._syncDependentInputs();
 
       // TODO: revisit this
       // Stop double-tap text selection.
@@ -48,6 +59,10 @@ export default class Settings {
 
   _onChange(event) {
     clearTimeout(this._throttleTimeout);
+
+    if (event.target.type === 'checkbox') {
+      this._syncDependentInputs();
+    }
 
     // throttle range
     if (event.target.type === 'range') {
@@ -77,11 +92,15 @@ export default class Settings {
       inputEl.checked = inputEl.hasAttribute('checked');
     }
 
+    this._syncDependentInputs();
+
     this.emitter.emit('reset', oldSettings);
     this.emitter.emit('change');
   }
 
   setSettings(settings) {
+    const jobOptions = settings.jobOptions ?? {};
+
     for (const inputEl of this._globalInputs) {
       if (!(inputEl.name in settings)) continue;
 
@@ -96,6 +115,21 @@ export default class Settings {
       if (!(inputEl.name in settings.jobs)) continue;
       inputEl.checked = settings.jobs[inputEl.name];
     }
+
+    for (const inputEl of this._jobOptionInputs) {
+      const parentJob = inputEl.dataset.parentJob;
+      const parentOptions = jobOptions[parentJob] ?? settings.jobs[parentJob];
+
+      if (
+        parentOptions &&
+        typeof parentOptions === 'object' &&
+        inputEl.name in parentOptions
+      ) {
+        inputEl.checked = parentOptions[inputEl.name];
+      }
+    }
+
+    this._syncDependentInputs();
   }
 
   getSettings() {
@@ -103,6 +137,7 @@ export default class Settings {
     const fingerprint = [];
     const output = {
       jobs: {},
+      jobOptions: {},
     };
 
     for (const inputEl of this._globalInputs) {
@@ -123,8 +158,34 @@ export default class Settings {
       output.jobs[inputEl.name] = inputEl.checked;
     }
 
+    for (const inputEl of this._jobOptionInputs) {
+      const parentJob = inputEl.dataset.parentJob;
+      const parentInput = this._jobInputMap.get(parentJob);
+
+      if (!output.jobOptions[parentJob]) {
+        output.jobOptions[parentJob] = {};
+      }
+
+      output.jobOptions[parentJob][inputEl.name] = inputEl.checked;
+
+      if (parentInput?.checked) {
+        fingerprint.push(
+          `${parentJob}:${inputEl.name}:${Number(inputEl.checked)}`,
+        );
+      }
+    }
+
     output.fingerprint = fingerprint.join(',');
 
     return output;
+  }
+
+  _syncDependentInputs() {
+    for (const inputEl of this._jobOptionInputs) {
+      const parentJob = inputEl.dataset.parentJob;
+      const parentInput = this._jobInputMap.get(parentJob);
+
+      inputEl.disabled = !parentInput?.checked;
+    }
   }
 }


### PR DESCRIPTION
This was suggested in noahbald/oxvg#234 by @noahbald, where I accidentally requested a feature that already existed. The only problem was that SVGOMG did not have any way to toggle individual options of features, so I had to implement this here for OXVGUI.
That's why this PR adds support for sub-toggles/options in general.

The true reason of this PR is having a way to automatically remove those annoying `xml:space="preserve"` attributes that show up often in my SVGs.